### PR TITLE
Redirect www to site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,9 @@
 [[redirects]]
+from = "https://www.spruceid.com/*"
+to = "https://site.spruceid.com/:splat"
+status = 200
+
+[[redirects]]
 from = "/*"
 to = "https://www.spruceid.com/:splat"
 status = 301


### PR DESCRIPTION
Proxy-redirect www subdomain to externally hosted website.

Reference: https://docs.netlify.com/routing/redirects/rewrites-proxies/#proxy-to-another-service